### PR TITLE
hostname needs to be in /etc/hosts

### DIFF
--- a/ubuntu16.04-simple/files/init
+++ b/ubuntu16.04-simple/files/init
@@ -5,5 +5,6 @@
 chown -R root:root /root
 
 echo "nanobox" > /etc/hostname
+echo "127.0.0.1    localhost nanobox" > /etc/hosts
 
 exec /sbin/init


### PR DESCRIPTION
hostname should be in `/etc/hosts` otherwise `sudo` will show this error:

```
sudo: unable to resolve host nanobox
```